### PR TITLE
Basic Integration is setup for Zeit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+yarn.lock
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# twilio-zeit-integration
+# Twilio-Zeit Integration
+
 Sets up the Zeit integration for use with Twilio

--- a/index.js
+++ b/index.js
@@ -1,0 +1,46 @@
+// The main output of the Zeit Integration - this is where the logic is handled and pulls in elements from /lib and /utils to handle authorization or htm returns.
+
+const { withUiHook } = require('@zeit/integration-utils');
+const { TWILIO_AUTH_TOK } = process.env;
+
+// Actions
+const disconnect = require('./lib/disconnect');
+const sendMsg = require('./lib/send-message');
+
+// Views
+const InfoView = require('./views/Info');
+const MessageView = require('./views/Message');
+const AuthorizeView = require('./views/Authorize');
+
+module.exports = withUiHook(async ({ payload, zeitClient }) => {
+    const metadata = await zeitClient.getMetadata();
+    const { action, query } = payload;
+
+    try {
+        switch (action) {
+            case 'disconnect':
+                await disconnect(zeitClient, metadata);
+                break;
+            case 'send-message':
+                await sendMsg(metadata.userTwilioSID, metadata.twilioAuth);
+                return InfoView(metadata);
+        }
+
+        if (query.AccountSid) {
+            metadata.userTwilioSID = query.AccountSid;
+            metadata.twilioAuth = TWILIO_AUTH_TOK;
+            await zeitClient.setMetadata(metadata);
+
+            return MessageView(metadata)
+        }
+
+        if (metadata.userTwilioSID && metadata.twilioAuth) {
+            await sendMsg(metadata.userTwilioSID, metadata.twilioAuth);
+        }
+
+        // if res is error=unauthorized_client, Twilio denied access
+        return AuthorizeView(payload);
+    } catch (error) {
+        console.log('Index.js main catch error: ', error)
+    }
+});

--- a/lib/disconnect.js
+++ b/lib/disconnect.js
@@ -1,0 +1,1 @@
+// Sets up a way for the user to disconnect the Twilio integration

--- a/lib/disconnect.js
+++ b/lib/disconnect.js
@@ -1,1 +1,7 @@
 // Sets up a way for the user to disconnect the Twilio integration
+
+module.exports = (zeitClient, metadata) => {
+    delete metadata.userTwilioSID;
+    delete metadata.twilioAuth;
+    return zeitClient.setMetadata(metadata)
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,1 @@
+// Future use, for cleaner importing and exporting through the integration and codebase

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,1 @@
-// Future use, for cleaner importing and exporting through the integration and codebase
+// Future use, for cleaner importing and exporting out of the /lib folder to the rest of the codebase

--- a/lib/send-message.js
+++ b/lib/send-message.js
@@ -1,1 +1,23 @@
 // Used to test sending a message with the established credentials to ensure the Twilio integration works
+
+// sid is the user's Twilio account SID; auth is the user's Twilio auth token
+
+// In the client.messages.create, the TO number is the number the message is being sent to, and the FROM number is the Twilio SMS enabled number on the user's account. Be sure that both numbers begin with +1 and contain no dashes
+
+const twilio = require('twilio');
+
+module.exports = async (sid, auth) => {
+    const client = new twilio(sid, auth);
+    console.log('SID: ', sid, '\nAUTH: ', auth);
+
+    try{
+        response = await client.messages.create({
+            body: 'Sent from Zeit',
+            to: '+17042231591',
+            from: '+19412567546'
+        });
+        console.log('Twilio message send try response: ', response);
+    } catch (error) {
+        console.log('Twilio message send catch error: ', error)
+    }
+}

--- a/lib/send-message.js
+++ b/lib/send-message.js
@@ -1,0 +1,1 @@
+// Used to test sending a message with the established credentials to ensure the Twilio integration works

--- a/now.json
+++ b/now.json
@@ -1,0 +1,14 @@
+{
+    "name": "twilio-zeit-integration",
+    "version": 2,
+    "builds": [
+        { "src": "index.js", "use": "@now/node"},
+        { "src": "utils/connect-with-twilio.js", "use": "@now/node"}
+    ],
+    "routes": [
+        {
+            "src": "/connect-with-twilio",
+            "dest": "utils/connect-with-twilio.js"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "zeit-test-integration",
+	"dependencies": {
+		"@zeit/integration-utils": "^0.5.1",
+		"cookie": "^0.4.0",
+		"dotenv": "^8.0.0",
+		"node-fetch": "^2.6.0",
+		"twilio": "^3.30.3"
+	}
+}

--- a/utils/connect-with-twilio.js
+++ b/utils/connect-with-twilio.js
@@ -1,0 +1,29 @@
+// A utility function for redirecting the user to the Twilio Connect authentication and then routing them back to the Zeit Integration upon success.
+
+// When successfully approved, Twilio returns the user back to the Integration with their aliased account SID as a query param. We will parse that information and save it to the Meta Store for future use with Zeit.
+
+const { parse: parseUrl } = require('url');
+const cookie = require('cookie');
+
+const { TWILIO_APP_SID } = process.env;
+
+module.exports = (req, res) => {
+    const {query} = parseUrl(req.url, true);
+
+    if (!query.next) {
+        res.writeHead(403);
+        res.end('Query param next is required!');
+        return;
+    }
+
+    const state = `state_${Math.random()}`;
+    const redirectUrl = `https://www.twilio.com/authorize/${TWILIO_APP_SID}`;
+    const context = {next: query.next, state};
+
+    res.writeHead(302, {
+        Location: redirectUrl,
+        'Set-Cookie': cookie.serialize('my-addon-context',
+        JSON.stringify(context), {path: '/'})
+    });
+    res.end('Redirecting...');
+}

--- a/views/Authorize.js
+++ b/views/Authorize.js
@@ -1,0 +1,1 @@
+// The authorize button returned when a user needs to initially connect to Twilio

--- a/views/Authorize.js
+++ b/views/Authorize.js
@@ -1,1 +1,15 @@
 // The authorize button returned when a user needs to initially connect to Twilio
+
+const { htm } = require('@zeit/integration-utils');
+
+module.exports = payload => {
+    const connectUrl = `https://twilio-zeit-integration.juliejonak.now.sh/connect-with-twilio?next=${encodeURIComponent(payload.installationUrl)}`
+
+    return htm`
+        <Page>
+            <Button>
+                <Link href=${connectUrl}>Authorize Twilio</Link>
+            </Button>
+        </Page>
+    `;
+};

--- a/views/Info.js
+++ b/views/Info.js
@@ -1,0 +1,1 @@
+// An element that returns the metadata once successfully stored to the meta store to ensure it matches the expected result

--- a/views/Info.js
+++ b/views/Info.js
@@ -1,1 +1,10 @@
 // An element that returns the metadata once successfully stored to the meta store to ensure it matches the expected result
+
+const { htm } = require('@zeit/integration-utils');
+
+module.exports = metadata => htm`
+    <Page>
+        <P>Saved SID: ${metadata.userTwilioSID}</P>
+        <P>Saved Auth Token: ${metadata.twilioAuth}</P>
+    </Page>
+`;

--- a/views/Message.js
+++ b/views/Message.js
@@ -1,0 +1,1 @@
+// An element that returns the metadata saved SID and Auth, plus a button with which to test sending a message from that user's Twilio account

--- a/views/Message.js
+++ b/views/Message.js
@@ -1,1 +1,12 @@
 // An element that returns the metadata saved SID and Auth, plus a button with which to test sending a message from that user's Twilio account
+
+const { htm } = require('@zeit/integration-utils');
+
+module.exports = metadata => htm`
+    <Page>
+        <P>SID: ${metadata.userTwilioSID}</P>
+        <P>Auth Token: ${metadata.twilioAuth}</P>
+
+        <Button action='send-message'>Send a message!</Button>
+    </Page>
+`;

--- a/views/index.js
+++ b/views/index.js
@@ -1,0 +1,1 @@
+// Future use, for cleaner importing and exporting out of the /views folder to the rest of the codebase


### PR DESCRIPTION
## Description
    
    Sets up the basic Zeit Twilio Integration as planned by the team, to begin testing if Twilio Connect will function within the Zeit Integration dashboard as expected.

   Creates an organized architecture for the code base, with separated actions and views for easy access and maintenance.
    
## Caveats
    
    - URLs and secrets may need updating as this has not yet gone into production/deploy
    - May have unknown bugs or errors that will only been seen once tested with a few users through their Twilio accounts
    - If Twilio Connect does not work as expected, will move on to a manual entry form for users to input their account SID and auth token one time.
    
### Checklist
    
    - [x] I have done a self-review of my code
    - [x] My code follows the existing file structure and code conventions
    - [ ] I have made corresponding changes to the documentation if neccessary (or opened a ticket to do so)
    - [ ] I have added tests to maintain code quality and test coverage (or opened a ticket to do so)